### PR TITLE
requirements.txt : downgrade emoji module to version emoji==1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4
 bleach
 cachetools
 configparser
-emoji
+emoji==1.7.0
 feedparser
 future
 geopy


### PR DESCRIPTION
fixes error:

module 'emoji' has no attribute 'get_emoji_regexp'

as mentioned in issue: https://github.com/artefactory/NLPretext/issues/225

Signed-off-by: vijaymalav564 <jaymalav10@gmail.com>